### PR TITLE
feat: update wedding app color palette

### DIFF
--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -36,8 +36,8 @@ const Features = () => <section id="features" className="py-24 md:py-32">
         {features.map((f, i) => <ScrollReveal key={f.title} delay={80}>
             <div className={`flex flex-col md:flex-row items-center gap-12 ${i % 2 === 1 ? "md:flex-row-reverse" : ""}`}>
               <div className="flex-1 space-y-4">
-                <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-accent/20">
-                  <f.icon className="w-6 h-6 text-accent" />
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary/10">
+                  <f.icon className="w-6 h-6 text-primary" />
                 </div>
                 <h3 className="font-heading text-2xl md:text-3xl font-semibold text-foreground">{f.title}</h3>
                 <p className="text-muted-foreground max-w-md text-pretty">{f.desc}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -7,52 +7,56 @@
 @layer base {
   :root {
     /* ── Page & sidebar background ───────────────────────────────────────────
-     * #F3EDEB — warm pinkish cream (confirmed image 2)                       */
-    --background:         14 25% 94%;
-    --foreground:         0 0% 16%;       /* #2A2A2A near-black text          */
+     * #F7F3EE — warm ivory                                                    */
+    --background:         33 36% 95.1%;
+    --foreground:         0 0% 17.3%;     /* #2C2C2C charcoal text            */
 
-    /* ── Cards — pure white panels ──────────────────────────────────────────  */
+    /* ── Cards — clean white panels ──────────────────────────────────────── */
     --card:               0 0% 100%;
-    --card-foreground:    0 0% 16%;
+    --card-foreground:    0 0% 17.3%;
     --popover:            0 0% 100%;
-    --popover-foreground: 0 0% 16%;
+    --popover-foreground: 0 0% 17.3%;
 
-    /* ── Primary — #839878 lighter sage green (confirmed by user) ────────── */
-    --primary:            99 13% 53%;
+    /* ── Primary — #3F5F47 dark green (buttons, brand) ────────────────────── */
+    --primary:            135 20.3% 31%;
     --primary-foreground: 0 0% 100%;
 
-    /* ── Secondary — soft sage ───────────────────────────────────────────── */
-    --secondary:          99 12% 75%;
-    --secondary-foreground: 99 13% 25%;
+    /* ── Secondary — #5F8D6B softer green (secondary emphasis/hover) ──────── */
+    --secondary:          136 19.5% 46.3%;
+    --secondary-foreground: 0 0% 100%;
 
-    /* ── Muted — #A89A93 warm tan (section labels: OVERVIEW, PLANNING) ───── */
-    --muted:              20 11% 88%;
-    --muted-foreground:   20 11% 62%;     /* #A89A93 confirmed image 1        */
+    /* ── Muted — warm neutral derived from the background/border hues ─────── */
+    --muted:              33 25% 91%;
+    --muted-foreground:   30 8% 42%;
 
-    /* ── Accent — golden amber (pending) ─────────────────────────────────── */
-    --accent:             38 58% 54%;     /* #D09B45                          */
-    --accent-foreground:  0 0% 16%;
+    /* ── Accent — #FCECEF subtle blush (badges, highlighted/selected states,
+     * hover backgrounds) — foreground is charcoal since the tint is very light */
+    --accent:             349 72.7% 95.7%;
+    --accent-foreground:  0 0% 17.3%;
+    /* Slightly deeper blush for decorative uses that need more visibility
+     * than the near-white --accent (e.g. small icons, gradient accents)    */
+    --accent-light:       349 45% 82%;
 
-    /* ── Destructive — dusty rose (declined) ─────────────────────────────── */
+    /* ── Destructive — stays semantically red/rose (declined, errors) ─────── */
     --destructive:        356 44% 59%;    /* #C9666E                          */
     --destructive-foreground: 0 0% 100%;
 
-    /* ── Borders — warm to match background hue ──────────────────────────── */
-    --border:             14 15% 86%;
-    --input:              14 15% 86%;
-    --ring:               99 13% 53%;
+    /* ── Borders — #E7DED4 warm beige ──────────────────────────────────────── */
+    --border:             32 28.4% 86.9%;
+    --input:              32 28.4% 86.9%;
+    --ring:               135 20.3% 31%;  /* matches primary — green focus rings, not blue */
 
     --radius: 0.75rem;
 
-    /* ── Sidebar — same background as page ───────────────────────────────── */
-    --sidebar-background:          14 25% 94%;
-    --sidebar-foreground:          0 0% 16%;
-    --sidebar-primary:             99 13% 53%;
+    /* ── Sidebar — same design system as the rest of the app ──────────────── */
+    --sidebar-background:          33 36% 95.1%;
+    --sidebar-foreground:          0 0% 17.3%;
+    --sidebar-primary:             135 20.3% 31%;
     --sidebar-primary-foreground:  0 0% 100%;
-    --sidebar-accent:              99 12% 75%;
-    --sidebar-accent-foreground:   99 13% 25%;
-    --sidebar-border:              14 15% 86%;
-    --sidebar-ring:                99 13% 53%;
+    --sidebar-accent:              136 19.5% 46.3%;
+    --sidebar-accent-foreground:   0 0% 100%;
+    --sidebar-border:              32 28.4% 86.9%;
+    --sidebar-ring:                135 20.3% 31%;
   }
 
   .dark {

--- a/src/pages/CreateInvitation.jsx
+++ b/src/pages/CreateInvitation.jsx
@@ -37,8 +37,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { getInvitationByUser, saveInvitation } from "@/lib/firestore";
 
 // ── Stitch-inspired color palette for the invitation canvas ───────────────────
-// These are kept separate from the ToGather design system tokens
-// so the builder feels like a distinct creative tool
+// This describes the actual wedding invitation artifact rendered in
+// <PhonePreview> (hero, greetings, RSVP button, etc.) — kept separate from the
+// ToGather design system tokens so the builder feels like a distinct creative
+// tool AND so recoloring the app's UI never touches the invitation itself.
+// Do NOT use CANVAS for the surrounding builder chrome (header/sidebar/panels)
+// — use BUILDER_UI below for that.
 const CANVAS = {
   primary:        "#56642b",   // olive green — main accent
   primaryLight:   "#8a9a5b",   // sage — secondary
@@ -51,6 +55,23 @@ const CANVAS = {
   outline:        "#76786b",   // borders
   secondary:      "#735c00",   // warm gold
   secondaryFixed: "#ffe088",   // light gold
+};
+
+// ── ToGather palette for the builder's own interface ───────────────────────────
+// Used for everything that is NOT the invitation artifact itself: the top bar,
+// left section nav, center settings panels, and Save/Publish actions. Selection
+// indicators (font pairing, layout, sidebar section, etc.) use a blush-tinted
+// background with a dark-green border/text instead of CANVAS's olive/lime.
+const BUILDER_UI = {
+  primary:          "#3F5F47", // dark green — active states, buttons, selected borders/text
+  primaryLight:     "#5F8D6B", // softer green — hover/secondary emphasis
+  selected:         "#FCECEF", // subtle blush tint — selected card/section background
+  surface:          "#F7F3EE", // warm ivory — page/header/sidebar/workspace background
+  surfaceContainer: "#FFFFFF", // white — panel cards & input backgrounds
+  surfaceHigh:      "#F3EAE3", // warm beige — icon wells, dropzones, toggle-off track
+  onSurface:        "#2C2C2C", // charcoal — primary text
+  onSurfaceVar:     "#746B63", // softer warm gray — labels/secondary text
+  outline:          "#E7DED4", // borders/dividers
 };
 
 // ── Section definitions — left sidebar nav ────────────────────────────────────
@@ -94,10 +115,10 @@ const PrivacyPanel = ({ settings, onChange }) => (
   <div className="space-y-8">
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-1"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Visibility
       </h3>
-      <p className="text-sm mb-6" style={{ color: CANVAS.onSurfaceVar }}>
+      <p className="text-sm mb-6" style={{ color: BUILDER_UI.onSurfaceVar }}>
         Control who can access your invitation link.
       </p>
       <div className="grid grid-cols-2 gap-4">
@@ -107,18 +128,18 @@ const PrivacyPanel = ({ settings, onChange }) => (
             className="p-6 rounded-lg border-2 text-left transition-all"
             style={{
               backgroundColor: settings.privacy === opt.toLowerCase()
-                ? CANVAS.primaryFixed : CANVAS.surfaceContainer,
+                ? BUILDER_UI.selected : BUILDER_UI.surfaceContainer,
               borderColor: settings.privacy === opt.toLowerCase()
-                ? CANVAS.primary : "transparent",
-              color: CANVAS.onSurface,
+                ? BUILDER_UI.primary : "transparent",
+              color: BUILDER_UI.onSurface,
             }}>
             <div className="flex items-center gap-3 mb-3">
               {opt === "Public"
-                ? <Globe size={20} style={{ color: CANVAS.primary }} />
-                : <Lock size={20} style={{ color: CANVAS.primary }} />}
+                ? <Globe size={20} style={{ color: BUILDER_UI.primary }} />
+                : <Lock size={20} style={{ color: BUILDER_UI.primary }} />}
             </div>
             <p className="font-bold text-sm">{opt}</p>
-            <p className="text-xs mt-1" style={{ color: CANVAS.onSurfaceVar }}>
+            <p className="text-xs mt-1" style={{ color: BUILDER_UI.onSurfaceVar }}>
               {opt === "Public"
                 ? "Anyone with the link can view"
                 : "Only invited guests can view"}
@@ -130,7 +151,7 @@ const PrivacyPanel = ({ settings, onChange }) => (
 
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         RSVP Deadline
       </h3>
       <Input
@@ -138,9 +159,9 @@ const PrivacyPanel = ({ settings, onChange }) => (
         value={settings.inviteDeadline || ""}
         onChange={e => onChange("inviteDeadline", e.target.value)}
         className="h-12 rounded-lg border-0 border-b-2"
-        style={{ borderColor: CANVAS.outline, backgroundColor: CANVAS.surfaceContainer }}
+        style={{ borderColor: BUILDER_UI.outline, backgroundColor: BUILDER_UI.surfaceContainer }}
       />
-      <p className="text-xs mt-2" style={{ color: CANVAS.onSurfaceVar }}>
+      <p className="text-xs mt-2" style={{ color: BUILDER_UI.onSurfaceVar }}>
         Guests cannot RSVP after this date.
       </p>
     </div>
@@ -152,7 +173,7 @@ const ColorPanel = ({ settings, onChange }) => (
   <div className="space-y-8">
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Theme Presets
       </h3>
       <div className="grid grid-cols-3 gap-3">
@@ -164,9 +185,11 @@ const ColorPanel = ({ settings, onChange }) => (
             }}
             className="p-4 rounded-lg border-2 transition-all text-center"
             style={{
+              // theme.bg / theme.primary / theme.secondary are the actual
+              // invitation preset colors (COLOR_THEMES) — never recolored.
               backgroundColor: theme.bg,
               borderColor: settings.colorPalette1 === theme.primary
-                ? CANVAS.primary : CANVAS.surfaceHigh,
+                ? BUILDER_UI.primary : BUILDER_UI.outline,
             }}>
             <div className="flex justify-center gap-1.5 mb-2">
               <div className="w-5 h-5 rounded-full"
@@ -174,7 +197,7 @@ const ColorPanel = ({ settings, onChange }) => (
               <div className="w-5 h-5 rounded-full"
                 style={{ backgroundColor: theme.secondary }} />
             </div>
-            <p className="text-xs font-bold" style={{ color: CANVAS.onSurface }}>
+            <p className="text-xs font-bold" style={{ color: BUILDER_UI.onSurface }}>
               {theme.name}
             </p>
           </button>
@@ -184,40 +207,42 @@ const ColorPanel = ({ settings, onChange }) => (
 
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Custom Colors
       </h3>
       <div className="grid grid-cols-2 gap-4">
         <div>
           <label className="text-xs font-bold tracking-widest uppercase mb-2 block"
-            style={{ color: CANVAS.onSurfaceVar }}>
+            style={{ color: BUILDER_UI.onSurfaceVar }}>
             Primary
           </label>
           <div className="flex items-center gap-3">
+            {/* Swatch + text input reflect the user's chosen invitation color —
+                only the surrounding wrapper/border uses the builder palette */}
             <input type="color" value={settings.colorPalette1 || "#56642b"}
               onChange={e => onChange("colorPalette1", e.target.value)}
               className="w-12 h-12 rounded-lg cursor-pointer border-0 p-1"
-              style={{ backgroundColor: CANVAS.surfaceContainer }} />
+              style={{ backgroundColor: BUILDER_UI.surfaceContainer }} />
             <Input value={settings.colorPalette1 || "#56642b"}
               onChange={e => onChange("colorPalette1", e.target.value)}
               className="h-11 rounded-lg border-0 border-b-2 font-mono text-sm"
-              style={{ borderColor: CANVAS.outline, backgroundColor: CANVAS.surfaceContainer }} />
+              style={{ borderColor: BUILDER_UI.outline, backgroundColor: BUILDER_UI.surfaceContainer }} />
           </div>
         </div>
         <div>
           <label className="text-xs font-bold tracking-widest uppercase mb-2 block"
-            style={{ color: CANVAS.onSurfaceVar }}>
+            style={{ color: BUILDER_UI.onSurfaceVar }}>
             Secondary
           </label>
           <div className="flex items-center gap-3">
             <input type="color" value={settings.colorPalette2 || "#8a9a5b"}
               onChange={e => onChange("colorPalette2", e.target.value)}
               className="w-12 h-12 rounded-lg cursor-pointer border-0 p-1"
-              style={{ backgroundColor: CANVAS.surfaceContainer }} />
+              style={{ backgroundColor: BUILDER_UI.surfaceContainer }} />
             <Input value={settings.colorPalette2 || "#8a9a5b"}
               onChange={e => onChange("colorPalette2", e.target.value)}
               className="h-11 rounded-lg border-0 border-b-2 font-mono text-sm"
-              style={{ borderColor: CANVAS.outline, backgroundColor: CANVAS.surfaceContainer }} />
+              style={{ borderColor: BUILDER_UI.outline, backgroundColor: BUILDER_UI.surfaceContainer }} />
           </div>
         </div>
       </div>
@@ -230,7 +255,7 @@ const FontPanel = ({ settings, onChange }) => (
   <div className="space-y-8">
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Font Pairings
       </h3>
       <div className="space-y-3">
@@ -243,26 +268,26 @@ const FontPanel = ({ settings, onChange }) => (
             className="w-full p-5 rounded-lg border-2 text-left transition-all"
             style={{
               backgroundColor: settings.font1 === pair.heading
-                ? CANVAS.primaryFixed : CANVAS.surfaceContainer,
+                ? BUILDER_UI.selected : BUILDER_UI.surfaceContainer,
               borderColor: settings.font1 === pair.heading
-                ? CANVAS.primary : "transparent",
+                ? BUILDER_UI.primary : "transparent",
             }}>
             <div className="flex justify-between items-center mb-2">
               <p className="text-xs font-bold tracking-widest uppercase"
-                style={{ color: CANVAS.onSurfaceVar }}>
+                style={{ color: BUILDER_UI.onSurfaceVar }}>
                 {pair.name}
               </p>
               {settings.font1 === pair.heading && (
                 <div className="w-5 h-5 rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: CANVAS.primary }}>
+                  style={{ backgroundColor: BUILDER_UI.primary }}>
                   <div className="w-2 h-2 rounded-full bg-white" />
                 </div>
               )}
             </div>
-            <p className="text-xl mb-1" style={{ fontFamily: pair.heading, color: CANVAS.onSurface }}>
+            <p className="text-xl mb-1" style={{ fontFamily: pair.heading, color: BUILDER_UI.onSurface }}>
               Sarah & Michael
             </p>
-            <p className="text-xs" style={{ fontFamily: pair.body, color: CANVAS.onSurfaceVar }}>
+            <p className="text-xs" style={{ fontFamily: pair.body, color: BUILDER_UI.onSurfaceVar }}>
               {pair.heading} / {pair.body}
             </p>
           </button>
@@ -277,7 +302,7 @@ const LayoutPanel = ({ settings, onChange }) => (
   <div className="space-y-8">
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Layout Style
       </h3>
       <div className="grid grid-cols-2 gap-4">
@@ -290,15 +315,15 @@ const LayoutPanel = ({ settings, onChange }) => (
             className="p-6 rounded-lg border-2 text-left transition-all"
             style={{
               backgroundColor: settings.layoutStyle === opt.id
-                ? CANVAS.primaryFixed : CANVAS.surfaceContainer,
+                ? BUILDER_UI.selected : BUILDER_UI.surfaceContainer,
               borderColor: settings.layoutStyle === opt.id
-                ? CANVAS.primary : "transparent",
-              color: CANVAS.onSurface,
+                ? BUILDER_UI.primary : "transparent",
+              color: BUILDER_UI.onSurface,
             }}>
             <LayoutDashboard size={24} className="mb-3"
-              style={{ color: CANVAS.primary }} />
+              style={{ color: BUILDER_UI.primary }} />
             <p className="font-bold text-sm mb-1">{opt.label}</p>
-            <p className="text-xs" style={{ color: CANVAS.onSurfaceVar }}>{opt.desc}</p>
+            <p className="text-xs" style={{ color: BUILDER_UI.onSurfaceVar }}>{opt.desc}</p>
           </button>
         ))}
       </div>
@@ -306,21 +331,21 @@ const LayoutPanel = ({ settings, onChange }) => (
 
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Hero Image
       </h3>
       <div className="border-2 border-dashed rounded-lg p-10 flex flex-col items-center text-center"
-        style={{ borderColor: CANVAS.outline, backgroundColor: CANVAS.surfaceContainer }}>
+        style={{ borderColor: BUILDER_UI.outline, backgroundColor: BUILDER_UI.surfaceContainer }}>
         <div className="w-14 h-14 rounded-full flex items-center justify-center mb-4"
-          style={{ backgroundColor: CANVAS.surfaceHigh }}>
-          <Upload size={22} style={{ color: CANVAS.primary }} />
+          style={{ backgroundColor: BUILDER_UI.surfaceHigh }}>
+          <Upload size={22} style={{ color: BUILDER_UI.primary }} />
         </div>
-        <p className="font-bold mb-1" style={{ color: CANVAS.onSurface }}>Upload Hero Image</p>
-        <p className="text-xs mb-5" style={{ color: CANVAS.onSurfaceVar }}>
+        <p className="font-bold mb-1" style={{ color: BUILDER_UI.onSurface }}>Upload Hero Image</p>
+        <p className="text-xs mb-5" style={{ color: BUILDER_UI.onSurfaceVar }}>
           High-resolution JPEG recommended
         </p>
         <button className="px-8 py-2 text-sm font-bold uppercase tracking-widest"
-          style={{ backgroundColor: CANVAS.onSurface, color: CANVAS.surface }}>
+          style={{ backgroundColor: BUILDER_UI.primary, color: "#FFFFFF" }}>
           Select File
         </button>
       </div>
@@ -333,7 +358,7 @@ const GreetingsPanel = ({ settings, onChange }) => (
   <div className="space-y-6">
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Invitation Title
       </h3>
       <Input
@@ -342,8 +367,8 @@ const GreetingsPanel = ({ settings, onChange }) => (
         placeholder="Together with their families..."
         className="h-12 rounded-lg border-0 border-b-2 italic"
         style={{
-          borderColor: CANVAS.outline,
-          backgroundColor: CANVAS.surfaceContainer,
+          borderColor: BUILDER_UI.outline,
+          backgroundColor: BUILDER_UI.surfaceContainer,
           fontFamily: settings.font1 || "Playfair Display",
           fontSize: "1.1rem",
         }}
@@ -351,7 +376,7 @@ const GreetingsPanel = ({ settings, onChange }) => (
     </div>
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Welcome Message
       </h3>
       <Textarea
@@ -360,12 +385,12 @@ const GreetingsPanel = ({ settings, onChange }) => (
         placeholder="The stars aligned when we met, and now we're getting married! Your presence at our wedding would make our special day even more memorable."
         className="min-h-[140px] rounded-lg border-0 border-b-2 resize-none"
         style={{
-          borderColor: CANVAS.outline,
-          backgroundColor: CANVAS.surfaceContainer,
-          color: CANVAS.onSurface,
+          borderColor: BUILDER_UI.outline,
+          backgroundColor: BUILDER_UI.surfaceContainer,
+          color: BUILDER_UI.onSurface,
         }}
       />
-      <p className="text-xs mt-2 text-right" style={{ color: CANVAS.onSurfaceVar }}>
+      <p className="text-xs mt-2 text-right" style={{ color: BUILDER_UI.onSurfaceVar }}>
         {(settings.greetingMessage || "").length}/300
       </p>
     </div>
@@ -379,16 +404,16 @@ const MusicPanel = ({ settings, onChange }) => {
     <div className="space-y-6">
       <div>
         <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-          style={{ color: CANVAS.onSurfaceVar }}>
+          style={{ color: BUILDER_UI.onSurfaceVar }}>
           Background Music
         </h3>
         <div className="border-2 border-dashed rounded-lg p-8 flex flex-col items-center text-center"
-          style={{ borderColor: CANVAS.outline, backgroundColor: CANVAS.surfaceContainer }}>
-          <Music size={28} className="mb-3" style={{ color: CANVAS.primary }} />
-          <p className="font-bold mb-1" style={{ color: CANVAS.onSurface }}>Upload Music</p>
-          <p className="text-xs mb-4" style={{ color: CANVAS.onSurfaceVar }}>MP3 or WAV, max 10MB</p>
+          style={{ borderColor: BUILDER_UI.outline, backgroundColor: BUILDER_UI.surfaceContainer }}>
+          <Music size={28} className="mb-3" style={{ color: BUILDER_UI.primary }} />
+          <p className="font-bold mb-1" style={{ color: BUILDER_UI.onSurface }}>Upload Music</p>
+          <p className="text-xs mb-4" style={{ color: BUILDER_UI.onSurfaceVar }}>MP3 or WAV, max 10MB</p>
           <button className="px-6 py-2 text-sm font-bold uppercase tracking-widest"
-            style={{ backgroundColor: CANVAS.onSurface, color: CANVAS.surface }}>
+            style={{ backgroundColor: BUILDER_UI.primary, color: "#FFFFFF" }}>
             Select File
           </button>
         </div>
@@ -396,26 +421,26 @@ const MusicPanel = ({ settings, onChange }) => {
 
       <div>
         <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-          style={{ color: CANVAS.onSurfaceVar }}>
+          style={{ color: BUILDER_UI.onSurfaceVar }}>
           Playback Settings
         </h3>
         <div className="p-4 rounded-lg flex items-center gap-4"
-          style={{ backgroundColor: CANVAS.surfaceContainer }}>
+          style={{ backgroundColor: BUILDER_UI.surfaceContainer }}>
           <div className="w-12 h-12 rounded-lg flex items-center justify-center"
-            style={{ backgroundColor: CANVAS.surfaceHigh }}>
-            <Music size={20} style={{ color: CANVAS.primary }} />
+            style={{ backgroundColor: BUILDER_UI.surfaceHigh }}>
+            <Music size={20} style={{ color: BUILDER_UI.primary }} />
           </div>
           <div className="flex-1">
-            <p className="text-sm font-bold" style={{ color: CANVAS.onSurface }}>
+            <p className="text-sm font-bold" style={{ color: BUILDER_UI.onSurface }}>
               {settings.musicTitle || "No song selected"}
             </p>
-            <p className="text-xs" style={{ color: CANVAS.onSurfaceVar }}>
+            <p className="text-xs" style={{ color: BUILDER_UI.onSurfaceVar }}>
               {settings.musicArtist || "Upload a song above"}
             </p>
           </div>
           <button onClick={() => setPlaying(!playing)}
             className="w-10 h-10 rounded-full flex items-center justify-center"
-            style={{ backgroundColor: CANVAS.primary }}>
+            style={{ backgroundColor: BUILDER_UI.primary }}>
             {playing
               ? <Pause size={18} className="text-white" />
               : <Play size={18} className="text-white" />}
@@ -424,13 +449,13 @@ const MusicPanel = ({ settings, onChange }) => {
 
         <div className="mt-4 flex items-center justify-between">
           <span className="text-xs font-bold tracking-widest uppercase"
-            style={{ color: CANVAS.onSurfaceVar }}>
+            style={{ color: BUILDER_UI.onSurfaceVar }}>
             Auto-play
           </span>
           <button
             onClick={() => onChange("musicAutoplay", !settings.musicAutoplay)}
             className="w-12 h-6 rounded-full transition-colors relative"
-            style={{ backgroundColor: settings.musicAutoplay ? CANVAS.primary : CANVAS.surfaceHigh }}>
+            style={{ backgroundColor: settings.musicAutoplay ? BUILDER_UI.primary : BUILDER_UI.surfaceHigh }}>
             <div className="w-5 h-5 bg-white rounded-full absolute top-0.5 transition-transform"
               style={{ transform: settings.musicAutoplay ? "translateX(26px)" : "translateX(2px)" }} />
           </button>
@@ -443,19 +468,19 @@ const MusicPanel = ({ settings, onChange }) => {
 // ── Center Panel: Date ────────────────────────────────────────────────────────
 const DatePanel = ({ invitation }) => (
   <div className="space-y-6">
-    <div className="p-5 rounded-lg" style={{ backgroundColor: CANVAS.surfaceContainer }}>
+    <div className="p-5 rounded-lg" style={{ backgroundColor: BUILDER_UI.surfaceContainer }}>
       <div className="flex items-center gap-2 mb-2">
-        <Info size={16} style={{ color: CANVAS.primary }} />
+        <Info size={16} style={{ color: BUILDER_UI.primary }} />
         <p className="text-xs font-bold tracking-widest uppercase"
-          style={{ color: CANVAS.onSurfaceVar }}>
+          style={{ color: BUILDER_UI.onSurfaceVar }}>
           From Wedding Details
         </p>
       </div>
-      <p className="text-sm" style={{ color: CANVAS.onSurface }}>
+      <p className="text-sm" style={{ color: BUILDER_UI.onSurface }}>
         The date on your invitation is pulled from your Wedding Details page.
         To change it, go to{" "}
         <Link to="/wedding-details" className="underline font-semibold"
-          style={{ color: CANVAS.primary }}>
+          style={{ color: BUILDER_UI.primary }}>
           Wedding Details
         </Link>.
       </p>
@@ -463,7 +488,7 @@ const DatePanel = ({ invitation }) => (
 
     <div>
       <h3 className="text-xs font-bold tracking-widest uppercase mb-4"
-        style={{ color: CANVAS.onSurfaceVar }}>
+        style={{ color: BUILDER_UI.onSurfaceVar }}>
         Display Options
       </h3>
       {[
@@ -472,13 +497,13 @@ const DatePanel = ({ invitation }) => (
         { id: "countdown",label: "Countdown",     desc: "Show a countdown timer to the wedding" },
       ].map(opt => (
         <div key={opt.id} className="flex items-center justify-between p-4 rounded-lg mb-2"
-          style={{ backgroundColor: CANVAS.surfaceContainer }}>
+          style={{ backgroundColor: BUILDER_UI.surfaceContainer }}>
           <div>
-            <p className="text-sm font-bold" style={{ color: CANVAS.onSurface }}>{opt.label}</p>
-            <p className="text-xs" style={{ color: CANVAS.onSurfaceVar }}>{opt.desc}</p>
+            <p className="text-sm font-bold" style={{ color: BUILDER_UI.onSurface }}>{opt.label}</p>
+            <p className="text-xs" style={{ color: BUILDER_UI.onSurfaceVar }}>{opt.desc}</p>
           </div>
           <div className="w-5 h-5 rounded border-2"
-            style={{ borderColor: CANVAS.primary, backgroundColor: CANVAS.primaryFixed }} />
+            style={{ borderColor: BUILDER_UI.primary, backgroundColor: BUILDER_UI.selected }} />
         </div>
       ))}
     </div>
@@ -792,11 +817,11 @@ const CreateInvitation = () => {
       default:
         return (
           <div className="flex flex-col items-center justify-center h-64 text-center">
-            <Sparkles size={32} className="mb-3" style={{ color: CANVAS.outline }} />
-            <p className="font-bold" style={{ color: CANVAS.onSurface }}>
+            <Sparkles size={32} className="mb-3" style={{ color: BUILDER_UI.outline }} />
+            <p className="font-bold" style={{ color: BUILDER_UI.onSurface }}>
               {SECTIONS.find(s => s.id === activeSection)?.label} settings
             </p>
-            <p className="text-sm mt-1" style={{ color: CANVAS.onSurfaceVar }}>
+            <p className="text-sm mt-1" style={{ color: BUILDER_UI.onSurfaceVar }}>
               Coming soon
             </p>
           </div>
@@ -808,10 +833,10 @@ const CreateInvitation = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center"
-        style={{ backgroundColor: CANVAS.surface }}>
+        style={{ backgroundColor: BUILDER_UI.surface }}>
         <div className="flex flex-col items-center gap-3">
-          <Loader2 size={28} className="animate-spin" style={{ color: CANVAS.primary }} />
-          <p className="text-sm" style={{ color: CANVAS.onSurfaceVar }}>Loading your invitation...</p>
+          <Loader2 size={28} className="animate-spin" style={{ color: BUILDER_UI.primary }} />
+          <p className="text-sm" style={{ color: BUILDER_UI.onSurfaceVar }}>Loading your invitation...</p>
         </div>
       </div>
     );
@@ -820,24 +845,24 @@ const CreateInvitation = () => {
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
     <div className="min-h-screen flex flex-col overflow-hidden"
-      style={{ backgroundColor: CANVAS.surface, fontFamily: settings.font2 || "DM Sans" }}>
+      style={{ backgroundColor: BUILDER_UI.surface, fontFamily: settings.font2 || "DM Sans" }}>
 
       {/* ── Top App Bar — ToGather style ── */}
       <header className="w-full sticky top-0 z-50 flex justify-between items-center px-8 h-16 border-b"
-        style={{ backgroundColor: CANVAS.surface, borderColor: `${CANVAS.outline}20` }}>
+        style={{ backgroundColor: BUILDER_UI.surface, borderColor: BUILDER_UI.outline }}>
         <div className="flex items-center gap-6">
           {/* Back to dashboard */}
           <Link to="/dashboard"
             className="flex items-center gap-2 text-sm font-medium transition-colors hover:opacity-70"
-            style={{ color: CANVAS.onSurfaceVar }}>
+            style={{ color: BUILDER_UI.onSurfaceVar }}>
             <ArrowLeft size={16} />
             Dashboard
           </Link>
 
-          <div className="h-5 w-px" style={{ backgroundColor: CANVAS.surfaceHigh }} />
+          <div className="h-5 w-px" style={{ backgroundColor: BUILDER_UI.outline }} />
 
           {/* Branding */}
-          <span className="font-heading text-xl font-semibold" style={{ color: CANVAS.primary }}>
+          <span className="font-heading text-xl font-semibold" style={{ color: BUILDER_UI.primary }}>
             ToGather
           </span>
 
@@ -846,7 +871,7 @@ const CreateInvitation = () => {
             {["Preview", "Share", "Settings"].map(tab => (
               <a key={tab} href="#"
                 className="font-heading italic text-lg tracking-tight transition-colors"
-                style={{ color: tab === "Settings" ? CANVAS.primary : `${CANVAS.primary}60` }}>
+                style={{ color: tab === "Settings" ? BUILDER_UI.primary : `${BUILDER_UI.primary}60` }}>
                 {tab}
               </a>
             ))}
@@ -856,7 +881,7 @@ const CreateInvitation = () => {
         <div className="flex items-center gap-3">
           {/* Draft saved indicator */}
           {saved && (
-            <span className="text-xs font-semibold" style={{ color: CANVAS.primary }}>
+            <span className="text-xs font-semibold" style={{ color: BUILDER_UI.primary }}>
               Saved ✓
             </span>
           )}
@@ -865,7 +890,7 @@ const CreateInvitation = () => {
           <button onClick={() => handleSave(false)}
             disabled={saving}
             className="px-5 py-2 text-sm font-semibold transition-colors hover:opacity-80 flex items-center gap-2"
-            style={{ color: CANVAS.primary }}>
+            style={{ color: BUILDER_UI.primary }}>
             {saving
               ? <><Loader2 size={14} className="animate-spin" /> Saving...</>
               : <><Save size={14} /> Save</>}
@@ -876,7 +901,7 @@ const CreateInvitation = () => {
             disabled={saving}
             className="px-6 py-2 text-sm font-semibold rounded-lg text-white shadow-sm transition-all active:scale-95"
             style={{
-              background: `linear-gradient(135deg, ${CANVAS.primary} 0%, ${CANVAS.primaryLight} 100%)`,
+              background: `linear-gradient(135deg, ${BUILDER_UI.primary} 0%, ${BUILDER_UI.primaryLight} 100%)`,
             }}>
             {settings.isPublished ? "Published ✓" : "Publish"}
           </button>
@@ -889,8 +914,8 @@ const CreateInvitation = () => {
         {/* Left sidebar — section navigation */}
         <aside className="w-64 flex-shrink-0 flex flex-col py-6 overflow-y-auto border-r"
           style={{
-            backgroundColor: "#f2f2eb",
-            borderColor: `${CANVAS.outline}15`,
+            backgroundColor: BUILDER_UI.surface,
+            borderColor: BUILDER_UI.outline,
             height: "calc(100vh - 4rem)",
             position: "sticky",
             top: "4rem",
@@ -900,16 +925,16 @@ const CreateInvitation = () => {
           <div className="px-6 mb-6">
             <div className="flex items-center gap-3">
               <div className="w-9 h-9 rounded-full flex items-center justify-center"
-                style={{ backgroundColor: `${CANVAS.primary}20` }}>
-                <Sparkles size={16} style={{ color: CANVAS.primary }} />
+                style={{ backgroundColor: `${BUILDER_UI.primary}20` }}>
+                <Sparkles size={16} style={{ color: BUILDER_UI.primary }} />
               </div>
               <div>
                 <p className="text-[10px] font-bold tracking-widest uppercase"
-                  style={{ color: CANVAS.onSurface }}>
+                  style={{ color: BUILDER_UI.onSurface }}>
                   Invitation Builder
                 </p>
                 <p className="text-[9px] uppercase tracking-tight"
-                  style={{ color: `${CANVAS.onSurfaceVar}70` }}>
+                  style={{ color: `${BUILDER_UI.onSurfaceVar}70` }}>
                   {invitation?.groomName?.first && invitation?.brideName?.first
                     ? `${invitation.groomName.first} & ${invitation.brideName.first}`
                     : "Your Wedding"}
@@ -928,8 +953,8 @@ const CreateInvitation = () => {
                   onClick={() => setActiveSection(sec.id)}
                   className="px-6 py-3 flex items-center gap-3 text-left transition-all text-xs font-bold tracking-widest uppercase"
                   style={{
-                    backgroundColor: isActive ? CANVAS.surface : "transparent",
-                    color: isActive ? CANVAS.primary : `${CANVAS.primary}50`,
+                    backgroundColor: isActive ? BUILDER_UI.selected : "transparent",
+                    color: isActive ? BUILDER_UI.primary : `${BUILDER_UI.primary}50`,
                     borderRadius: isActive ? "0 2rem 2rem 0" : undefined,
                     marginLeft: isActive ? "1rem" : undefined,
                     paddingLeft: isActive ? "1rem" : undefined,
@@ -945,23 +970,23 @@ const CreateInvitation = () => {
 
         {/* Center workspace — active section controls */}
         <main className="flex-1 overflow-y-auto p-10"
-          style={{ backgroundColor: "#f4f4ef" }}>
+          style={{ backgroundColor: BUILDER_UI.surface }}>
           <div className="max-w-2xl mx-auto">
 
             {/* Section header */}
             <div className="flex justify-between items-end mb-10">
               <div>
                 <h2 className="text-3xl font-semibold mb-1"
-                  style={{ color: CANVAS.onSurface }}>
+                  style={{ color: BUILDER_UI.onSurface }}>
                   {SECTIONS.find(s => s.id === activeSection)?.label || "Settings"}
                 </h2>
                 <p className="text-xs uppercase tracking-widest font-bold"
-                  style={{ color: CANVAS.onSurfaceVar }}>
+                  style={{ color: BUILDER_UI.onSurfaceVar }}>
                   Configuration Panel
                 </p>
               </div>
               {saved && (
-                <span className="text-xs font-bold" style={{ color: CANVAS.primary }}>
+                <span className="text-xs font-bold" style={{ color: BUILDER_UI.primary }}>
                   Draft Saved ✓
                 </span>
               )}
@@ -972,11 +997,13 @@ const CreateInvitation = () => {
           </div>
         </main>
 
-        {/* Right side — phone preview */}
+        {/* Right side — phone preview. This surrounding "stage" area is builder
+            chrome; the <PhonePreview> component itself keeps the invitation's
+            own CANVAS / user-selected colors untouched. */}
         <aside className="w-[400px] flex-shrink-0 flex items-center justify-center border-l"
           style={{
-            backgroundColor: CANVAS.surface,
-            borderColor: `${CANVAS.outline}10`,
+            backgroundColor: BUILDER_UI.surface,
+            borderColor: BUILDER_UI.outline,
             height: "calc(100vh - 4rem)",
             position: "sticky",
             top: "4rem",

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -46,7 +46,7 @@ const getInitials = (name = "") =>
 const avatarColor = (name = "") => {
   const colors = [
     "bg-primary/20 text-primary",
-    "bg-accent/20 text-accent",
+    "bg-accent text-accent-foreground",
     "bg-secondary/20 text-secondary",
     "bg-blue-100 text-blue-600",
     "bg-orange-100 text-orange-600",
@@ -65,10 +65,13 @@ const timeAgo = (timestamp) => {
   return `${Math.floor(diff / 86400)} days ago`;
 };
 
-// Returns the right color classes for each RSVP status badge — exact Figma hex
+// Returns the right color classes for each RSVP status badge — tuned to
+// harmonize with the ToGather warm palette while keeping each status's
+// semantic color (accepted = green, declined = red, pending = amber).
+// Kept in sync with the identical map in GuestList.jsx.
 const statusBadge = (status) => {
   const map = {
-    Accepted: "bg-[#E6EFEA] text-[#3C6B54]",
+    Accepted: "bg-[#E7F0EA] text-[#3F5F47]",
     Declined: "bg-[#F7E6E6] text-[#C9666E]",
     Pending:  "bg-[#FDF3E1] text-[#D09B45]",
   };
@@ -307,9 +310,9 @@ const Dashboard = () => {
   // Percentage of guests who have responded (accepted or declined)
   const progress = total > 0 ? Math.round(((accepted + declined) / total) * 100) : 0;
 
-  // Donut chart data — exact Figma colors
+  // Donut chart data — matches the statusBadge colors above
   const rsvpChartData = [
-    { name: "Accepted", value: accepted || 0, color: "#3C6B54" },
+    { name: "Accepted", value: accepted || 0, color: "#3F5F47" },
     { name: "Declined", value: declined || 0, color: "#C9666E" },
     { name: "Pending",  value: pending  || 0, color: "#D09B45" },
   ];
@@ -424,7 +427,7 @@ const Dashboard = () => {
               </div>
 
               {/* Mini invitation preview */}
-              <div className="bg-[#f9f6f2] rounded-xl border border-border/30 p-6 text-center mb-4 min-h-[160px] flex flex-col items-center justify-center">
+              <div className="bg-muted/60 rounded-xl border border-border/30 p-6 text-center mb-4 min-h-[160px] flex flex-col items-center justify-center">
                 {coupleNames ? (
                   <>
                     <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-2">
@@ -483,14 +486,14 @@ const Dashboard = () => {
                         data={
                           total > 0
                             ? rsvpChartData
-                            : [{ name: "empty", value: 1, color: "hsl(24, 16%, 88%)" }]
+                            : [{ name: "empty", value: 1, color: "hsl(32, 20%, 88%)" }]
                         }
                         cx="50%" cy="50%"
                         innerRadius={42} outerRadius={58}
                         dataKey="value"
                         strokeWidth={0}
                       >
-                        {(total > 0 ? rsvpChartData : [{ color: "hsl(24, 16%, 88%)" }]).map((d, i) => (
+                        {(total > 0 ? rsvpChartData : [{ color: "hsl(32, 20%, 88%)" }]).map((d, i) => (
                           <Cell key={i} fill={d.color} />
                         ))}
                       </Pie>
@@ -508,7 +511,7 @@ const Dashboard = () => {
                 {/* Legend */}
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center gap-2">
-                    <span className="w-2.5 h-2.5 rounded-full bg-[#3C6B54]" />
+                    <span className="w-2.5 h-2.5 rounded-full bg-[#3F5F47]" />
                     <span className="font-medium text-foreground">{accepted}</span>
                     <span className="text-muted-foreground">Accepted</span>
                   </div>

--- a/src/pages/GuestList.jsx
+++ b/src/pages/GuestList.jsx
@@ -46,7 +46,7 @@ const getInitials = (name = "") =>
 const avatarColor = (name = "") => {
   const colors = [
     "bg-primary/20 text-primary",
-    "bg-accent/20 text-accent",
+    "bg-accent text-accent-foreground",
     "bg-secondary/20 text-secondary",
     "bg-blue-100 text-blue-600",
     "bg-orange-100 text-orange-600",
@@ -55,10 +55,13 @@ const avatarColor = (name = "") => {
   return colors[name.charCodeAt(0) % colors.length];
 };
 
-// Returns Tailwind classes for the RSVP status badge — exact Figma hex
+// Returns Tailwind classes for the RSVP status badge — tuned to harmonize
+// with the ToGather warm palette while keeping each status's semantic color
+// (accepted = green, declined = red, pending = amber).
+// Kept in sync with the identical map in Dashboard.jsx.
 const statusBadge = (status) => {
   const map = {
-    Accepted: "bg-[#E6EFEA] text-[#3C6B54] border border-[#3C6B54]/15",
+    Accepted: "bg-[#E7F0EA] text-[#3F5F47] border border-[#3F5F47]/15",
     Declined: "bg-[#F7E6E6] text-[#C9666E] border border-[#C9666E]/20",
     Pending:  "bg-[#FDF3E1] text-[#D09B45] border border-[#D09B45]/25",
   };

--- a/src/pages/RSVP.jsx
+++ b/src/pages/RSVP.jsx
@@ -85,7 +85,7 @@ const InvitationHeader = ({ invitation }) => {
     <div className="mb-10 animate-fade-up text-center">
       <div className="mb-4 flex items-center justify-center gap-3">
         <div className="h-px w-16 bg-gradient-to-r from-transparent to-border" />
-        <Heart size={14} className="fill-accent text-accent" />
+        <Heart size={14} className="fill-accent-light text-accent-light" />
         <div className="h-px w-16 bg-gradient-to-l from-transparent to-border" />
       </div>
 
@@ -116,7 +116,7 @@ const InvitationHeader = ({ invitation }) => {
       )}
 
       {invitation?.inviteDeadline && (
-        <p className="mt-2 text-xs font-medium text-accent">
+        <p className="mt-2 text-xs font-medium text-primary">
           Kindly reply by{" "}
           {new Date(invitation.inviteDeadline + "T00:00:00").toLocaleDateString(
             "en-US",
@@ -131,7 +131,7 @@ const InvitationHeader = ({ invitation }) => {
 
       <div className="mt-5 flex items-center justify-center gap-3">
         <div className="h-px w-16 bg-gradient-to-r from-transparent to-border" />
-        <Heart size={14} className="fill-accent text-accent" />
+        <Heart size={14} className="fill-accent-light text-accent-light" />
         <div className="h-px w-16 bg-gradient-to-l from-transparent to-border" />
       </div>
     </div>
@@ -426,7 +426,7 @@ const ConfirmationScreen = ({ isAttending, name, invitation, coupleNames }) => (
         {isAttending ? (
           <Heart size={40} className="fill-primary/30 text-primary" />
         ) : (
-          <Sparkles size={40} className="text-accent" />
+          <Sparkles size={40} className="text-accent-light" />
         )}
       </div>
 

--- a/src/pages/WeddingDetails.jsx
+++ b/src/pages/WeddingDetails.jsx
@@ -33,8 +33,8 @@ const SectionCard = ({
 }) => <ScrollReveal delay={delay}>
     <section className="bg-card rounded-2xl border border-border/50 shadow-md shadow-foreground/[0.03] p-6 sm:p-8">
       <div className="flex items-center gap-3 mb-6">
-        <div className="w-10 h-10 rounded-xl bg-accent/15 flex items-center justify-center">
-          <Icon size={20} className="text-accent" />
+        <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+          <Icon size={20} className="text-primary" />
         </div>
         <h2 className="font-heading text-xl font-semibold text-foreground italic">{title}</h2>
       </div>


### PR DESCRIPTION
Centralize the app's color system on the new ToGather warm palette (#3F5F47 primary, #5F8D6B secondary, #FCECEF accent, #F7F3EE background, #E7DED4 border, #2C2C2C foreground):

- src/index.css: rework light-mode CSS variables (background, foreground, primary, secondary, muted, accent, border/input/ring, sidebar-*); add a missing --accent-light token used by tailwind.config.js.
- Dashboard.jsx / GuestList.jsx: sync RSVP status badge, donut chart, and avatar colors with the new palette; fix accent-on-light contrast issue in avatar initials.
- WeddingDetails.jsx / Features.jsx / RSVP.jsx: fix icon/text contrast regressions caused by the new (much lighter) accent color.
- CreateInvitation.jsx: introduce a separate BUILDER_UI palette for the invitation builder's own chrome (header, sidebar, settings panels, Save/Publish buttons), replacing the old olive/lime selection styling. The CANVAS palette, COLOR_THEMES presets, and all user-selected invitation colors in <PhonePreview> are intentionally left untouched.